### PR TITLE
fix(laravel-soap-8): "Uri", "location" not set if config is used

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -360,6 +360,8 @@ class SoapClient
                     $this->{Str::camel($setupItem)}();
                 } elseif (is_array($setupItemConfig)) {
                     $this->{Str::camel($setupItem)}($this->arrayKeysToCamel($setupItemConfig));
+                } elseif (is_string($setupItemConfig)) {
+                    $this->{Str::camel($setupItem)}($setupItemConfig);
                 }
             }
         }


### PR DESCRIPTION
Issue:

## What I did

added string check for config values

closes #8 

## How to test

- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature", "bug", "documentation", "maintenance"]`

-->
