### PR TITLE
Support Laravel v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-json": "*",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "illuminate/support": "^5.6 || ^6.0 || ^7.0",
+        "illuminate/support": "^5.6 || ^6.0 || ^7.0 || ^8.0",
         "phpro/soap-client": "^1.1",
         "php-http/guzzle6-adapter": "^2.0",
         "php-http/discovery": "^1.7",
@@ -26,7 +26,7 @@
     "require-dev": {
         "symfony/var-dumper": "^5.0",
         "phpunit/phpunit": "^9.1",
-        "orchestra/testbench": "^5.1",
+        "orchestra/testbench": "^5.1 || ^6.0",
         "laminas/laminas-code": "^3.4",
         "wsdl2phpgenerator/wsdl2phpgenerator": "^3.4"
     },


### PR DESCRIPTION
Issue:

Would like to support Laravel v8

## What I did

Added version constraints for Laravel v8 and the corresponding testbench

## How to test

phpunit - all passes when pulling in L8

- Does this need an update to the documentation?

No.
