### PR TITLE
[BREAKING CHANGE] Support laravel 8 (again - sorry!)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-json": "*",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "illuminate/support": "^5.6 || ^6.0 || ^7.0",
+        "illuminate/support": "^5.6 || ^6.0 || ^7.0 || ^8.0",
         "phpro/soap-client": "^1.1",
         "php-http/guzzle6-adapter": "^2.0",
         "php-http/discovery": "^1.7",
@@ -26,7 +26,7 @@
     "require-dev": {
         "symfony/var-dumper": "^5.0",
         "phpunit/phpunit": "^9.1",
-        "orchestra/testbench": "^5.1",
+        "orchestra/testbench": "^5.1 || ^6.0",
         "laminas/laminas-code": "^3.4",
         "wsdl2phpgenerator/wsdl2phpgenerator": "^3.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-simplexml": "*",
         "illuminate/support": "^5.6 || ^6.0 || ^7.0 || ^8.0",
         "phpro/soap-client": "^1.1",
-        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/guzzle7-adapter": "^0.1",
         "php-http/discovery": "^1.7",
         "php-http/message": "^1.8",
         "php-http/client-common": "^2.1",


### PR DESCRIPTION
Issue:

The last PR allowed illuminate/support v8 - but I hadn't spotted that a full Laravel 8 install also needed the `php-http/guzzle-adaptor` bumped to the `-7` package.  Which is a bit annoying - but there we go.  I think this is a breaking change as you can't install the -7 adapter on Laravel < 8.

## What I did

Changed the `php-http/guzzle6-adapter` to `php-http/guzzle7-adapter`.

## How to test

phpunit & a `laravel new test-soap` and then do a `composer require codedredd/laravel-soap`.  Currently fails without bumping to the guzzle7 adapter.

- Does this need an update to the documentation?

I wasn't sure whether to write up the docs if this become a 'v2.x' or not.  I can add them into the PR if that's what will be happening though.



<!--

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature", "bug", "documentation", "maintenance"]`

-->
