### PR TITLE
Fix namespaces for testing classes

### DIFF
--- a/tests/Unit/Xml/SoapXmlTest.php
+++ b/tests/Unit/Xml/SoapXmlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CodeDredd\Soap\Xml;
+namespace CodeDredd\Soap\Tests\Unit\Xml;
 
 use CodeDredd\Soap\Tests\TestCase;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapEngineFactory;

--- a/tests/Unit/Xml/XmlSerializerTest.php
+++ b/tests/Unit/Xml/XmlSerializerTest.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace CodeDredd\Soap\Xml;
+namespace CodeDredd\Soap\Tests\Unit\Xml;
 
 use CodeDredd\Soap\Tests\TestCase;
+use CodeDredd\Soap\Xml\SoapXml;
+use CodeDredd\Soap\Xml\XMLSerializer;
 
 class XmlSerializerTest extends TestCase
 {


### PR DESCRIPTION
## What I did

- Improving the testing class namespaces for `tests/Unit/Xml/SoapXmlTest.php` and `tests/Unit/Xml/XmlSerializerTest.php`.
And it should let these classes be compatible with `PSR-4` autloading.