### PR TITLE
Guzzle6 issue fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1846,7 +1846,7 @@
                 "nyholm/psr7": "^1.3",
                 "php-http/client-common": "^2.1",
                 "php-http/discovery": "^1.7",
-                "php-http/guzzle6-adapter": "^2.0.1",
+                "php-http/guzzle7-adapter": "^0.1",
                 "php-http/httplug": "^2.1",
                 "php-http/message": "^1.8",
                 "php-http/message-factory": "^1.0",


### PR DESCRIPTION
Issue:

Changed `php-http/guzzle6-adapter` to `php-http/guzzle7-adapter` in `composer.lock.json`

<!--
## How to test

- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.


Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature", "bug", "documentation", "maintenance"]`

-->
