### PR TITLE
Change method visibility

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -129,7 +129,7 @@ class SoapClient
      * @param  HandlerInterface|null  $handler
      * @return $this
      */
-    private function setHandler(HandlerInterface $handler = null)
+    protected function setHandler(HandlerInterface $handler = null)
     {
         $this->handler = $handler ?? HttPlugHandle::createForClient(
                 Client::createWithConfig($this->handlerOptions)
@@ -142,7 +142,7 @@ class SoapClient
     /**
      * Adds middleware to the handler.
      */
-    private function addMiddleware()
+    protected function addMiddleware()
     {
         foreach ($this->middlewares as $middleware) {
             $this->handler->addMiddleware($middleware);
@@ -395,7 +395,7 @@ class SoapClient
      * @param  array  $items
      * @return array
      */
-    private function arrayKeysToCamel(array $items)
+    protected function arrayKeysToCamel(array $items)
     {
         $changedItems = [];
         foreach ($items as $key => $value) {
@@ -501,7 +501,7 @@ class SoapClient
     /**
      * @return $this
      */
-    private function refreshEngine()
+    protected function refreshEngine()
     {
         $this->refreshExtSoapOptions();
         $this->engine = ExtSoapEngineFactory::fromOptionsWithHandler(
@@ -513,7 +513,7 @@ class SoapClient
         return $this;
     }
 
-    private function refreshExtSoapOptions()
+    protected function refreshExtSoapOptions()
     {
         if ($this->factory->isRecording()) {
             $this->baseWsdl($this->factory->getFakeWsdl());


### PR DESCRIPTION
## Issue / Use Case
In our system, some configuration options (e.g. basic auth credentials) are encrypted. I need to be able to extend the `SoapClient` with my own method for bootstrapping the client at runtime (similar to `buildClient`). Some methods are declared as `private`, preventing this.

Again, I need this on the v1.x branch, but I can create a PR for v2 as well if this gets merged.
