### PR TITLE
Allow client class configuration

### DIFF
--- a/docs/client/configuration.md
+++ b/docs/client/configuration.md
@@ -30,3 +30,27 @@ Headers may be added to requests using the `withHeaders` method. This `withHeade
         'X-First' => 'foo',
         'X-Second' => 'bar'
     ])->baseWsdl('http://test.com'/v1?wsdl)->call('Get_Users');
+
+## Custom Client Class
+
+You are free to extend the SOAP client class used internally by this 
+package, by defining your own class and extending the package client:
+
+    use CodeDredd\Soap\SoapClient as BaseClient;
+    
+    class SoapClient extends BaseClient
+    {
+        // ...
+    }
+
+After defining your class, you may instruct the factory to use your 
+custom class. Typically, this will happen in the `boot` method of 
+your application's `App\Providers\AppServiceProvider` class:
+
+    use App\Soap\SoapClient;
+    use CodeDredd\Soap\SoapFactory;
+    
+    public function boot()
+    {
+        SoapFactory::useClientClass(SoapClient::class);
+    }

--- a/src/SoapFactory.php
+++ b/src/SoapFactory.php
@@ -17,11 +17,11 @@ class SoapFactory
     }
 
     /**
-     * The client model class name.
+     * The client class name.
      *
      * @var string
      */
-    public static $clientModel = 'CodeDredd\Soap\SoapClient';
+    public static $clientClass = 'CodeDredd\Soap\SoapClient';
 
     /**
      * The stub callables that will handle requests.
@@ -261,22 +261,22 @@ class SoapFactory
     }
 
     /**
-     * Get a new client model instance.
+     * Get a new client class instance.
      *
      * @return SoapClient
      */
     public function client()
     {
-        return new static::$clientModel($this);
+        return new static::$clientClass($this);
     }
 
     /**
-     * Set the client model class name.
+     * Set the client class name.
      *
-     * @param string $clientModel
+     * @param string $clientClass
      */
-    public static function useClientModel(string $clientModel): void
+    public static function useClientClass(string $clientClass): void
     {
-        static::$clientModel = $clientModel;
+        static::$clientClass = $clientClass;
     }
 }

--- a/src/SoapFactory.php
+++ b/src/SoapFactory.php
@@ -17,6 +17,13 @@ class SoapFactory
     }
 
     /**
+     * The client model class name.
+     *
+     * @var string
+     */
+    public static $clientModel = 'CodeDredd\Soap\SoapClient';
+
+    /**
      * The stub callables that will handle requests.
      *
      * @var \Illuminate\Support\Collection
@@ -74,7 +81,7 @@ class SoapFactory
             return (new SoapTesting($this))->{$method}(...$parameters);
         }
 
-        return tap(new SoapClient($this), function ($request) {
+        return tap($this->client(), function ($request) {
             $request->stub($this->stubCallbacks);
         })->{$method}(...$parameters);
     }
@@ -251,5 +258,25 @@ class SoapFactory
         return collect($this->recorded)->filter(function ($pair) use ($callback) {
             return $callback($pair[0], $pair[1]);
         });
+    }
+
+    /**
+     * Get a new client model instance.
+     *
+     * @return SoapClient
+     */
+    public function client()
+    {
+        return new static::$clientModel($this);
+    }
+
+    /**
+     * Set the client model class name.
+     *
+     * @param string $clientModel
+     */
+    public static function useClientModel(string $clientModel): void
+    {
+        static::$clientModel = $clientModel;
     }
 }

--- a/tests/Fixtures/CustomSoapClient.php
+++ b/tests/Fixtures/CustomSoapClient.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CodeDredd\Soap\Tests\Fixtures;
+
+use CodeDredd\Soap\SoapClient;
+
+class CustomSoapClient extends SoapClient
+{
+    public function buildClient(string $setup = '')
+    {
+        $this->baseWsdl(__DIR__.'/Wsdl/weather.wsdl');
+        $this->withHandlerOptions([
+            'handler' => $this->buildHandlerStack(),
+        ]);
+        $this->refreshEngine();
+        $this->isClientBuilded = true;
+
+        return $this;
+    }
+}

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -125,13 +125,13 @@ class SoapClientTest extends TestCase
             'with_fake_string' => ['Get_Post', $fakeResponse, ['response' => 'Test']],
         ];
     }
-    
-    public function testSoapClientModelMayBeCustomized(): void
+
+    public function testSoapClientClassMayBeCustomized(): void
     {
         Soap::fake();
         $client = Soap::buildClient('laravel_soap');
         $this->assertInstanceOf(SoapClient::class, $client);
-        SoapFactory::useClientModel(CustomSoapClient::class);
+        SoapFactory::useClientClass(CustomSoapClient::class);
         $client = Soap::buildClient('laravel_soap');
         $this->assertInstanceOf(CustomSoapClient::class, $client);
     }

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -5,6 +5,9 @@ namespace CodeDredd\Soap\Tests\Unit;
 use CodeDredd\Soap\Client\Request;
 use CodeDredd\Soap\Client\Response;
 use CodeDredd\Soap\Facades\Soap;
+use CodeDredd\Soap\SoapClient;
+use CodeDredd\Soap\SoapFactory;
+use CodeDredd\Soap\Tests\Fixtures\CustomSoapClient;
 use CodeDredd\Soap\Tests\TestCase;
 
 class SoapClientTest extends TestCase
@@ -121,5 +124,15 @@ class SoapClientTest extends TestCase
             'with_fake_array' => ['Get_Users', $fakeResponse, $fakeResponse['Get_Users']],
             'with_fake_string' => ['Get_Post', $fakeResponse, ['response' => 'Test']],
         ];
+    }
+    
+    public function testSoapClientModelMayBeCustomized(): void
+    {
+        Soap::fake();
+        $client = Soap::buildClient('laravel_soap');
+        $this->assertInstanceOf(SoapClient::class, $client);
+        SoapFactory::useClientModel(CustomSoapClient::class);
+        $client = Soap::buildClient('laravel_soap');
+        $this->assertInstanceOf(CustomSoapClient::class, $client);
     }
 }


### PR DESCRIPTION
Added the ability to configure the client model used by the factory.
This way, users can overwrite the client model used by the factory, like so (in a service provider):
```php
SoapFactory::useClientModel(CustomSoapClient::class);
```

Combined with the method visibility changes from my other PR, we can now replace the default soap client with our own implementation (e.g. to use a custom `buildClient` method), but still use the `Soap` facade.
