### PR TITLE
feat(laravel-soap-125): Adding auth middleware for DHL

### DIFF
--- a/src/Facades/Soap.php
+++ b/src/Facades/Soap.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \CodeDredd\Soap\SoapClient withWsa()
  * @method static \CodeDredd\Soap\SoapClient withRemoveEmptyNodes()
  * @method static \CodeDredd\Soap\SoapClient withBasicAuth(string $username, string $password)
+ * @method static \CodeDredd\Soap\SoapClient withCisDHLAuth($user, ?string $signature = null)
  * @method \CodeDredd\Soap\Client\Response call(string $method, array $arguments = [])
  * @method static \GuzzleHttp\Promise\PromiseInterface response($body = null, $status = 200, array $headers = [])
  * @method static \CodeDredd\Soap\Client\ResponseSequence sequence(array $responses = [])

--- a/src/Middleware/CisDhlMiddleware.php
+++ b/src/Middleware/CisDhlMiddleware.php
@@ -52,7 +52,7 @@ class CisDhlMiddleware extends Middleware
         $domDoc->documentElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:cis', self::CIS_NS);
 
         $header = $domDoc->createElementNS('http://schemas.xmlsoap.org/soap/envelope/', 'SOAP-ENV:Header');
-        $cisAuth = $domDoc->createElementNS(self::CIS_NS, 'cis:Authentication');
+        $cisAuth = $domDoc->createElementNS(self::CIS_NS, 'cis:Authentification');
 
         $envelope->insertBefore($header, $envelope->firstChild);
 

--- a/src/Middleware/CisDhlMiddleware.php
+++ b/src/Middleware/CisDhlMiddleware.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace CodeDredd\Soap\Middleware;
+
+use Http\Promise\Promise;
+use Phpro\SoapClient\Middleware\Middleware;
+use Phpro\SoapClient\Xml\SoapXml;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class CisDhlMiddleware extends Middleware
+{
+    /**
+     * @var string
+     */
+    const CIS_NS = 'http://dhl.de/webservice/cisbase';
+
+    /**
+     * @var string
+     */
+    private $user;
+
+    /**
+     * @var string
+     */
+    private $signature;
+
+    public function __construct(string $user, string $signature)
+    {
+        $this->user = $user;
+        $this->signature = $signature;
+    }
+
+    public function getName(): string
+    {
+        return 'cis_dhl_middleware';
+    }
+
+    /**
+     * @param callable         $handler
+     * @param RequestInterface $request
+     *
+     * @return Promise
+     */
+    public function beforeRequest(callable $handler, RequestInterface $request): Promise
+    {
+        $xml = SoapXml::fromStream($request->getBody());
+        $xml->registerNamespace('cis', 'http://dhl.de/webservice/cisbase');
+        $envelope = $xml->xpath('/soap:Envelope')->item(0);
+
+        $domDoc = $xml->getXmlDocument();
+        $domDoc->documentElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:cis', self::CIS_NS);
+
+        $header = $domDoc->createElementNS('http://schemas.xmlsoap.org/soap/envelope/', 'SOAP-ENV:Header');
+        $cisAuth = $domDoc->createElementNS(self::CIS_NS, 'cis:Authentication');
+
+        $envelope->insertBefore($header, $envelope->firstChild);
+
+        if (!empty($this->user) && !empty($this->signature)) {
+            $cisUser = $domDoc->createElementNS(self::CIS_NS, 'cis:user', $this->user);
+            $cisSig = $domDoc->createElementNS(self::CIS_NS, 'cis:signature', $this->signature);
+            $cisAuth->appendChild($cisUser);
+            $cisAuth->appendChild($cisSig);
+        }
+        $header->appendChild($cisAuth);
+
+        return $handler($request->withBody($xml->toStream()));
+    }
+
+    /**
+     * @param ResponseInterface $response
+     *
+     * @return ResponseInterface
+     */
+    public function afterResponse(ResponseInterface $response): ResponseInterface
+    {
+        return $response;
+    }
+}

--- a/src/Middleware/CisDhlMiddleware.php
+++ b/src/Middleware/CisDhlMiddleware.php
@@ -56,7 +56,7 @@ class CisDhlMiddleware extends Middleware
 
         $envelope->insertBefore($header, $envelope->firstChild);
 
-        if (!empty($this->user) && !empty($this->signature)) {
+        if (! empty($this->user) && ! empty($this->signature)) {
             $cisUser = $domDoc->createElementNS(self::CIS_NS, 'cis:user', $this->user);
             $cisSig = $domDoc->createElementNS(self::CIS_NS, 'cis:signature', $this->signature);
             $cisAuth->appendChild($cisUser);

--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -8,6 +8,7 @@ use CodeDredd\Soap\Driver\ExtSoap\ExtSoapEngineFactory;
 use CodeDredd\Soap\Exceptions\NotFoundConfigurationException;
 use CodeDredd\Soap\Exceptions\SoapException;
 use CodeDredd\Soap\Handler\HttPlugHandle;
+use CodeDredd\Soap\Middleware\CisDhlMiddleware;
 use CodeDredd\Soap\Middleware\WsseMiddleware;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
@@ -207,6 +208,24 @@ class SoapClient
 
         $this->middlewares = array_merge_recursive($this->middlewares, [
             'basic' => new BasicAuthMiddleware($username, $password),
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * @param  string|array  $user
+     * @param  string|null  $signature
+     * @return $this
+     */
+    public function withCisDHLAuth($user, ?string $signature = null)
+    {
+        if (is_array($user)) {
+            ['username' => $user, 'password' => $signature] = $user;
+        }
+
+        $this->middlewares = array_merge_recursive($this->middlewares, [
+            'dhl' => new CisDhlMiddleware($user, $signature),
         ]);
 
         return $this;

--- a/tests/Unit/Middleware/CisDhlMiddlewareTest.php
+++ b/tests/Unit/Middleware/CisDhlMiddlewareTest.php
@@ -15,6 +15,6 @@ class CisDhlMiddlewareTest extends TestCase
         $lastRequest = $client->getEngine()->collectLastRequestInfo()->getLastRequest();
 
         self::assertTrue($response->ok());
-        self::assertStringContainsString('<cis:Authentication>', $lastRequest);
+        self::assertStringContainsString('<cis:Authentification>', $lastRequest);
     }
 }

--- a/tests/Unit/Middleware/CisDhlMiddlewareTest.php
+++ b/tests/Unit/Middleware/CisDhlMiddlewareTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CodeDredd\Soap\Tests\Unit\Middleware;
+
+use CodeDredd\Soap\Facades\Soap;
+use CodeDredd\Soap\Tests\TestCase;
+
+class CisDhlMiddlewareTest extends TestCase
+{
+    public function testCisDHLMiddleware()
+    {
+        Soap::fake();
+        $client = Soap::withCisDHLAuth('test', 'dhl')->baseWsdl('https://laravel-soap.wsdl');
+        $response = $client->call('Get_User');
+        $lastRequest = $client->getEngine()->collectLastRequestInfo()->getLastRequest();
+
+        self::assertTrue($response->ok());
+        self::assertStringContainsString('<cis:Authentication>', $lastRequest);
+    }
+}


### PR DESCRIPTION
This adds a custom middleware used by DHL

`
$client = Soap::withCisDHLAuth('user', 'signature')
`

closes #125 