### PR TITLE
fix(laravel-soap-126): Arguments wrong passed with call method

### DIFF
--- a/src/Driver/ExtSoap/AbusedClient.php
+++ b/src/Driver/ExtSoap/AbusedClient.php
@@ -62,7 +62,7 @@ class AbusedClient extends \SoapClient
 
     public function collectRequest(): SoapRequest
     {
-        if (!$this->storedRequest) {
+        if (! $this->storedRequest) {
             throw new \RuntimeException('No request has been registered yet.');
         }
 
@@ -80,12 +80,12 @@ class AbusedClient extends \SoapClient
         $this->storedResponse = null;
     }
 
-    public function __getLastRequest() : string
+    public function __getLastRequest(): string
     {
         return $this->__last_request;
     }
 
-    public function __getLastResponse() : string
+    public function __getLastResponse(): string
     {
         return $this->__last_response;
     }

--- a/src/Driver/ExtSoap/AbusedClient.php
+++ b/src/Driver/ExtSoap/AbusedClient.php
@@ -4,14 +4,49 @@ declare(strict_types=1);
 
 namespace CodeDredd\Soap\Driver\ExtSoap;
 
-use Phpro\SoapClient\Soap\Driver\ExtSoap\AbusedClient as PhproAbusedClient;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptionsResolverFactory;
 use Phpro\SoapClient\Soap\HttpBinding\SoapRequest;
+use Phpro\SoapClient\Soap\HttpBinding\SoapResponse;
 use Phpro\SoapClient\Xml\SoapXml;
 
-class AbusedClient extends PhproAbusedClient
+class AbusedClient extends \SoapClient
 {
-    public static function createFromOptions(ExtSoapOptions $options): PhproAbusedClient
+    /**
+     * @var SoapRequest|null
+     */
+    protected $storedRequest;
+
+    /**
+     * @var SoapResponse|null
+     */
+    protected $storedResponse;
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Internal SoapClient property for storing last request.
+     *
+     * @var string
+     */
+    protected $__last_request = '';
+    // @codingStandardsIgnoreEnd
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Internal SoapClient property for storing last response.
+     *
+     * @var string
+     */
+    protected $__last_response = '';
+    // @codingStandardsIgnoreEnd
+
+    public function __construct($wsdl, array $options = [])
+    {
+        $options = ExtSoapOptionsResolverFactory::createForWsdl($wsdl)->resolve($options);
+        parent::__construct($wsdl, $options);
+    }
+
+    public static function createFromOptions(ExtSoapOptions $options): self
     {
         return new self($options->getWsdl(), $options->getOptions());
     }
@@ -23,5 +58,35 @@ class AbusedClient extends PhproAbusedClient
         $this->storedRequest = new SoapRequest($request, $location, $action, $version, (int) $oneWay);
 
         return $this->storedResponse ? $this->storedResponse->getResponse() : '';
+    }
+
+    public function collectRequest(): SoapRequest
+    {
+        if (!$this->storedRequest) {
+            throw new \RuntimeException('No request has been registered yet.');
+        }
+
+        return $this->storedRequest;
+    }
+
+    public function registerResponse(SoapResponse $response)
+    {
+        $this->storedResponse = $response;
+    }
+
+    public function cleanUpTemporaryState()
+    {
+        $this->storedRequest = null;
+        $this->storedResponse = null;
+    }
+
+    public function __getLastRequest() : string
+    {
+        return $this->__last_request;
+    }
+
+    public function __getLastResponse() : string
+    {
+        return $this->__last_response;
     }
 }

--- a/src/Driver/ExtSoap/ExtSoapDecoder.php
+++ b/src/Driver/ExtSoap/ExtSoapDecoder.php
@@ -34,6 +34,7 @@ class ExtSoapDecoder implements DecoderInterface
         } finally {
             $this->client->cleanUpTemporaryState();
         }
+
         return $decoded;
     }
 }

--- a/src/Driver/ExtSoap/ExtSoapDecoder.php
+++ b/src/Driver/ExtSoap/ExtSoapDecoder.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeDredd\Soap\Driver\ExtSoap;
+
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Generator\DummyMethodArgumentsGenerator;
+use Phpro\SoapClient\Soap\Engine\DecoderInterface;
+use Phpro\SoapClient\Soap\HttpBinding\SoapResponse;
+
+class ExtSoapDecoder implements DecoderInterface
+{
+    /**
+     * @var AbusedClient
+     */
+    private $client;
+
+    /**
+     * @var DummyMethodArgumentsGenerator
+     */
+    private $argumentsGenerator;
+
+    public function __construct(AbusedClient $client, DummyMethodArgumentsGenerator $argumentsGenerator)
+    {
+        $this->client = $client;
+        $this->argumentsGenerator = $argumentsGenerator;
+    }
+
+    public function decode(string $method, SoapResponse $response)
+    {
+        $this->client->registerResponse($response);
+        try {
+            $decoded = $this->client->__soapCall($method, $this->argumentsGenerator->generateForSoapCall($method));
+        } finally {
+            $this->client->cleanUpTemporaryState();
+        }
+        return $decoded;
+    }
+}

--- a/src/Driver/ExtSoap/ExtSoapDriver.php
+++ b/src/Driver/ExtSoap/ExtSoapDriver.php
@@ -2,15 +2,90 @@
 
 namespace CodeDredd\Soap\Driver\ExtSoap;
 
-use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapDriver as PhproExtSoapDriver;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Generator\DummyMethodArgumentsGenerator;
+use Phpro\SoapClient\Soap\Engine\DecoderInterface;
+use Phpro\SoapClient\Soap\Engine\DriverInterface;
+use Phpro\SoapClient\Soap\Engine\EncoderInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataFactory;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+use Phpro\SoapClient\Soap\HttpBinding\SoapRequest;
+use Phpro\SoapClient\Soap\HttpBinding\SoapResponse;
 
-class ExtSoapDriver extends PhproExtSoapDriver
+class ExtSoapDriver implements DriverInterface
 {
-    public static function createFromOptions(ExtSoapOptions $options): PhproExtSoapDriver
+    /**
+     * @var AbusedClient
+     */
+    private $client;
+
+    /**
+     * @var EncoderInterface
+     */
+    private $encoder;
+
+    /**
+     * @var DecoderInterface
+     */
+    private $decoder;
+
+    /**
+     * @var MetadataInterface
+     */
+    private $metadata;
+
+    public function __construct(
+        AbusedClient $client,
+        EncoderInterface $encoder,
+        DecoderInterface $decoder,
+        MetadataInterface $metadata
+    ) {
+
+        $this->client = $client;
+        $this->encoder = $encoder;
+        $this->decoder = $decoder;
+        $this->metadata = $metadata;
+    }
+
+    public static function createFromOptions(ExtSoapOptions $options): self
     {
         $client = AbusedClient::createFromOptions($options);
 
-        return self::createFromClient($client);
+        return self::createFromClient(
+            $client,
+            MetadataFactory::manipulated(new ExtSoapMetadata($client), $options->getMetadataOptions())
+        );
+    }
+
+    public static function createFromClient(AbusedClient $client, MetadataInterface $metadata = null): self
+    {
+        $metadata = $metadata ?? MetadataFactory::lazy(new ExtSoapMetadata($client));
+
+        return new self(
+            $client,
+            new ExtSoapEncoder($client),
+            new ExtSoapDecoder($client, new DummyMethodArgumentsGenerator($metadata)),
+            $metadata
+        );
+    }
+
+    public function decode(string $method, SoapResponse $response)
+    {
+        return $this->decoder->decode($method, $response);
+    }
+
+    public function encode(string $method, array $arguments): SoapRequest
+    {
+        return $this->encoder->encode($method, $arguments);
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return $this->metadata;
+    }
+
+    public function getClient(): AbusedClient
+    {
+        return $this->client;
     }
 }

--- a/src/Driver/ExtSoap/ExtSoapDriver.php
+++ b/src/Driver/ExtSoap/ExtSoapDriver.php
@@ -40,7 +40,6 @@ class ExtSoapDriver implements DriverInterface
         DecoderInterface $decoder,
         MetadataInterface $metadata
     ) {
-
         $this->client = $client;
         $this->encoder = $encoder;
         $this->decoder = $decoder;

--- a/src/Driver/ExtSoap/ExtSoapEncoder.php
+++ b/src/Driver/ExtSoap/ExtSoapEncoder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeDredd\Soap\Driver\ExtSoap;
+
+use Phpro\SoapClient\Soap\Engine\EncoderInterface;
+use Phpro\SoapClient\Soap\HttpBinding\SoapRequest;
+
+class ExtSoapEncoder implements EncoderInterface
+{
+    /**
+     * @var AbusedClient
+     */
+    private $client;
+
+    public function __construct(AbusedClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function encode(string $method, array $arguments): SoapRequest
+    {
+        try {
+            $this->client->__soapCall($method, $arguments);
+            $encoded = $this->client->collectRequest();
+        } finally {
+            $this->client->cleanUpTemporaryState();
+        }
+
+        return $encoded;
+    }
+}

--- a/src/Driver/ExtSoap/ExtSoapEngineFactory.php
+++ b/src/Driver/ExtSoap/ExtSoapEngineFactory.php
@@ -18,6 +18,6 @@ class ExtSoapEngineFactory
     ) {
         $driver = ExtSoapDriver::createFromOptions($options);
 
-        return $withMocking ? new EngineFaker($driver, $handler, $options->getWsdl()) : new Engine($driver, $handler);
+        return $withMocking ? new EngineFaker($driver, $handler, $options) : new Engine($driver, $handler);
     }
 }

--- a/src/Driver/ExtSoap/ExtSoapMetadata.php
+++ b/src/Driver/ExtSoap/ExtSoapMetadata.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeDredd\Soap\Driver\ExtSoap;
+
+use CodeDredd\Soap\Driver\ExtSoap\Metadata\MethodsParser;
+use CodeDredd\Soap\Driver\ExtSoap\Metadata\TypesParser;
+use CodeDredd\Soap\Driver\ExtSoap\Metadata\XsdTypesParser;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\XsdTypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+
+class ExtSoapMetadata implements MetadataInterface
+{
+    /**
+     * @var AbusedClient
+     */
+    private $abusedClient;
+
+    /**
+     * @var XsdTypeCollection|null
+     */
+    private $xsdTypes;
+
+    public function __construct(AbusedClient $abusedClient)
+    {
+        $this->abusedClient = $abusedClient;
+    }
+
+    public function getMethods(): MethodCollection
+    {
+        return (new MethodsParser($this->getXsdTypes()))->parse($this->abusedClient);
+    }
+
+    public function getTypes(): TypeCollection
+    {
+        return (new TypesParser($this->getXsdTypes()))->parse($this->abusedClient);
+    }
+
+    private function getXsdTypes(): XsdTypeCollection
+    {
+        if (null === $this->xsdTypes) {
+            $this->xsdTypes = XsdTypesParser::default()->parse($this->abusedClient);
+        }
+
+        return $this->xsdTypes;
+    }
+}

--- a/src/Driver/ExtSoap/Metadata/MethodsParser.php
+++ b/src/Driver/ExtSoap/Metadata/MethodsParser.php
@@ -36,6 +36,7 @@ class MethodsParser
     private function parseMethodFromString(string $methodString): Method
     {
         $methodString = $this->transformListResponseToArray($methodString);
+
         return new Method(
             $this->parseName($methodString),
             $this->parseParameters($methodString),
@@ -54,7 +55,7 @@ class MethodsParser
     private function parseParameters(string $methodString): array
     {
         preg_match('/\((.*)\)/', $methodString, $properties);
-        if (!$properties[1]) {
+        if (! $properties[1]) {
             return [];
         }
 
@@ -62,7 +63,7 @@ class MethodsParser
 
         return array_map(
             function (string $parameter): Parameter {
-                list($type, $name) = explode(' ', trim($parameter));
+                [$type, $name] = explode(' ', trim($parameter));
 
                 return new Parameter(
                     ltrim($name, '$'),

--- a/src/Driver/ExtSoap/Metadata/MethodsParser.php
+++ b/src/Driver/ExtSoap/Metadata/MethodsParser.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeDredd\Soap\Driver\ExtSoap\Metadata;
+
+use CodeDredd\Soap\Driver\ExtSoap\AbusedClient;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\XsdTypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Parameter;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+
+class MethodsParser
+{
+    /**
+     * @var XsdTypeCollection
+     */
+    private $xsdTypes;
+
+    public function __construct(XsdTypeCollection $xsdTypes)
+    {
+        $this->xsdTypes = $xsdTypes;
+    }
+
+    public function parse(AbusedClient $abusedClient): MethodCollection
+    {
+        return new MethodCollection(...array_map(
+            function (string $methodString) {
+                return $this->parseMethodFromString($methodString);
+            },
+            $abusedClient->__getFunctions()
+        ));
+    }
+
+    private function parseMethodFromString(string $methodString): Method
+    {
+        $methodString = $this->transformListResponseToArray($methodString);
+        return new Method(
+            $this->parseName($methodString),
+            $this->parseParameters($methodString),
+            $this->parseReturnType($methodString)
+        );
+    }
+
+    private function transformListResponseToArray(string $methodString): string
+    {
+        return preg_replace('/^list\(([^\)]*)\)(.*)/i', 'array$2', $methodString);
+    }
+
+    /**
+     * @return Parameter[]
+     */
+    private function parseParameters(string $methodString): array
+    {
+        preg_match('/\((.*)\)/', $methodString, $properties);
+        if (!$properties[1]) {
+            return [];
+        }
+
+        $parameters = preg_split('/,\s?/', $properties[1]);
+
+        return array_map(
+            function (string $parameter): Parameter {
+                list($type, $name) = explode(' ', trim($parameter));
+
+                return new Parameter(
+                    ltrim($name, '$'),
+                    $this->xsdTypes->fetchByNameWithFallback($type)
+                );
+            },
+            $parameters
+        );
+    }
+
+    private function parseName(string $methodString): string
+    {
+        preg_match('/^\w+ (?P<name>\w+)/', $methodString, $matches);
+
+        return (string) $matches['name'];
+    }
+
+    private function parseReturnType(string $methodString): XsdType
+    {
+        preg_match('/^(?P<returnType>\w+)/', $methodString, $matches);
+
+        return $this->xsdTypes->fetchByNameWithFallback((string) $matches['returnType']);
+    }
+}

--- a/src/Driver/ExtSoap/Metadata/TypesParser.php
+++ b/src/Driver/ExtSoap/Metadata/TypesParser.php
@@ -30,7 +30,7 @@ class TypesParser
         foreach ($soapTypes as $soapType) {
             $properties = [];
             $lines = explode("\n", $soapType);
-            if (!preg_match('/struct (?P<typeName>.*) {/', $lines[0], $matches)) {
+            if (! preg_match('/struct (?P<typeName>.*) {/', $lines[0], $matches)) {
                 continue;
             }
             $xsdType = XsdType::create($matches['typeName']);

--- a/src/Driver/ExtSoap/Metadata/TypesParser.php
+++ b/src/Driver/ExtSoap/Metadata/TypesParser.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeDredd\Soap\Driver\ExtSoap\Metadata;
+
+use CodeDredd\Soap\Driver\ExtSoap\AbusedClient;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\XsdTypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Property;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+
+class TypesParser
+{
+    /**
+     * @var XsdTypeCollection
+     */
+    private $xsdTypes;
+
+    public function __construct(XsdTypeCollection $xsdTypes)
+    {
+        $this->xsdTypes = $xsdTypes;
+    }
+
+    public function parse(AbusedClient $abusedClient): TypeCollection
+    {
+        $collection = new TypeCollection();
+        $soapTypes = $abusedClient->__getTypes();
+        foreach ($soapTypes as $soapType) {
+            $properties = [];
+            $lines = explode("\n", $soapType);
+            if (!preg_match('/struct (?P<typeName>.*) {/', $lines[0], $matches)) {
+                continue;
+            }
+            $xsdType = XsdType::create($matches['typeName']);
+
+            foreach (array_slice($lines, 1) as $line) {
+                if ($line === '}') {
+                    continue;
+                }
+                preg_match('/\s* (?P<propertyType>.*) (?P<propertyName>.*);/', $line, $matches);
+                $properties[] = new Property(
+                    $matches['propertyName'],
+                    $this->xsdTypes->fetchByNameWithFallback($matches['propertyType'])
+                );
+            }
+
+            $collection->add(new Type($xsdType, $properties));
+        }
+
+        return $collection;
+    }
+}

--- a/src/Driver/ExtSoap/Metadata/XsdTypesParser.php
+++ b/src/Driver/ExtSoap/Metadata/XsdTypesParser.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeDredd\Soap\Driver\ExtSoap\Metadata;
+
+use CodeDredd\Soap\Driver\ExtSoap\AbusedClient;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Visitor\ListVisitor;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Visitor\SimpleTypeVisitor;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Visitor\UnionVisitor;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Visitor\XsdTypeVisitorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\XsdTypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+
+class XsdTypesParser
+{
+    /**
+     * @var XsdTypeVisitorInterface[]
+     */
+    private $visitors;
+
+    public function __construct(XsdTypeVisitorInterface ...$visitors)
+    {
+        $this->visitors = $visitors;
+    }
+
+    public static function default(): self
+    {
+        return new self(
+            new ListVisitor(),
+            new UnionVisitor(),
+            new SimpleTypeVisitor()
+        );
+    }
+
+    public function parse(AbusedClient $abusedClient): XsdTypeCollection
+    {
+        $collection = new XsdTypeCollection();
+        $soapTypes = $abusedClient->__getTypes();
+        foreach ($soapTypes as $soapType) {
+            if ($type = $this->detectXsdType($soapType)) {
+                $collection->add($type);
+            }
+        }
+
+        return $collection;
+    }
+
+    private function detectXsdType(string $soapType): ?XsdType
+    {
+        foreach ($this->visitors as $visitor) {
+            if ($type = $visitor($soapType)) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Faker/EngineFaker.php
+++ b/src/Faker/EngineFaker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CodeDredd\Soap\Faker;
 
 use CodeDredd\Soap\Xml\XMLSerializer;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
 use Phpro\SoapClient\Soap\Engine\DriverInterface;
 use Phpro\SoapClient\Soap\Engine\EngineInterface;
 use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
@@ -28,24 +29,24 @@ class EngineFaker implements EngineInterface
     private $handler;
 
     /**
-     * @var string
+     * @var ExtSoapOptions
      */
-    private $wsdl;
+    private $options;
 
     /**
      * EngineFaker constructor.
      * @param  DriverInterface  $driver
      * @param  HandlerInterface  $handler
-     * @param  string  $wsdl
+     * @param  ExtSoapOptions  $options
      */
     public function __construct(
         DriverInterface $driver,
         HandlerInterface $handler,
-        $wsdl = ''
+        ExtSoapOptions $options
     ) {
         $this->driver = $driver;
         $this->handler = $handler;
-        $this->wsdl = $wsdl;
+        $this->options = $options;
     }
 
     /**
@@ -63,7 +64,8 @@ class EngineFaker implements EngineInterface
      */
     public function request(string $method, array $arguments)
     {
-        $request = new SoapRequest(XMLSerializer::arrayToSoapXml($arguments), $this->wsdl, $method, 1);
+        $options = $this->options->getOptions();
+        $request = new SoapRequest(XMLSerializer::arrayToSoapXml($arguments), $this->options->getWsdl(), $method, $options['soap_version']);
         $response = $this->handler->request($request);
 
         return json_decode($response->getResponse());

--- a/src/Faker/EngineFaker.php
+++ b/src/Faker/EngineFaker.php
@@ -65,7 +65,7 @@ class EngineFaker implements EngineInterface
     public function request(string $method, array $arguments)
     {
         $options = $this->options->getOptions();
-        $request = new SoapRequest(XMLSerializer::arrayToSoapXml($arguments), $this->options->getWsdl(), $method, $options['soap_version']);
+        $request = new SoapRequest(XMLSerializer::arrayToSoapXml($arguments), $this->options->getWsdl(), $method, $options['soap_version'] ?? SOAP_1_1);
         $response = $this->handler->request($request);
 
         return json_decode($response->getResponse());

--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -327,7 +327,7 @@ class SoapClient
             return $this->macroCall($method, $parameters);
         }
 
-        return $this->call($method, $parameters[0]);
+        return $this->call($method, $parameters[0] ?? $parameters);
     }
 
     /**

--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -327,7 +327,7 @@ class SoapClient
             return $this->macroCall($method, $parameters);
         }
 
-        return $this->call($method, $parameters);
+        return $this->call($method, $parameters[0]);
     }
 
     /**
@@ -347,6 +347,7 @@ class SoapClient
                 }
                 $arguments = $arguments->validated();
             }
+            $arguments = [$arguments];
             $result = $this->engine->request($method, $arguments);
             if ($result instanceof ResultProviderInterface) {
                 $result = Response::fromSoapResponse($result->getResult());

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -150,6 +150,11 @@ class SoapClientTest extends TestCase
             'Fahrenheit' => 75,
         ]);
         self::assertArrayHasKey('FahrenheitToCelsiusResult', $result->json());
+
+        $result = $client->FahrenheitToCelsius([
+            'Fahrenheit' => 75,
+        ]);
+        self::assertArrayHasKey('FahrenheitToCelsiusResult', $result->json());
     }
 
     /**

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -126,6 +126,35 @@ class SoapClientTest extends TestCase
         ];
     }
 
+    public function testSoapOptions(): void
+    {
+        Soap::fake();
+        $client = Soap::withOptions(['soap_version' => SOAP_1_2])->baseWsdl('https://laravel-soap.wsdl');
+        $response = $client->call('Get_User');
+        $lastRequestInfo = $client->getEngine()->collectLastRequestInfo();
+
+        self::assertTrue($response->ok());
+        self::assertStringContainsString('application/soap+xml; charset="utf-8', $lastRequestInfo->getLastRequestHeaders());
+    }
+
+    /**
+     *
+     */
+    public function testRealSoapCall(): void
+    {
+        $this->markTestSkipped('Real Soap Call Testing. Comment the line out for testing');
+        // location has to be set because the wsdl has a wrong location declaration
+        $client = Soap::baseWsdl('https://www.w3schools.com/xml/tempconvert.asmx?wsdl')
+                      ->withOptions([
+                          'soap_version' => SOAP_1_2,
+                          'location' => 'https://www.w3schools.com/xml/tempconvert.asmx?wsdl'
+                      ]);
+        $result = $client->call('FahrenheitToCelsius', [
+            'Fahrenheit' => 75
+        ]);
+        self::assertArrayHasKey('FahrenheitToCelsiusResult', $result->json());
+    }
+
     /**
      * @dataProvider soapHeaderProvider
      * @param $header

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -137,9 +137,6 @@ class SoapClientTest extends TestCase
         self::assertStringContainsString('application/soap+xml; charset="utf-8', $lastRequestInfo->getLastRequestHeaders());
     }
 
-    /**
-     *
-     */
     public function testRealSoapCall(): void
     {
         $this->markTestSkipped('Real Soap Call Testing. Comment the line out for testing');
@@ -147,10 +144,10 @@ class SoapClientTest extends TestCase
         $client = Soap::baseWsdl('https://www.w3schools.com/xml/tempconvert.asmx?wsdl')
                       ->withOptions([
                           'soap_version' => SOAP_1_2,
-                          'location' => 'https://www.w3schools.com/xml/tempconvert.asmx?wsdl'
+                          'location' => 'https://www.w3schools.com/xml/tempconvert.asmx?wsdl',
                       ]);
         $result = $client->call('FahrenheitToCelsius', [
-            'Fahrenheit' => 75
+            'Fahrenheit' => 75,
         ]);
         self::assertArrayHasKey('FahrenheitToCelsiusResult', $result->json());
     }


### PR DESCRIPTION
If a soap call was made with `client->call('action', arrayParameters)` the parameters were not included because its need to be wrapped in an array again.

Also the faker engine now has the right soap options in the request.
