### PR TITLE
fix(laravel-soap-126): 400 Bad Request, XML not as expected

### DIFF
--- a/src/Middleware/WsseMiddleware.php
+++ b/src/Middleware/WsseMiddleware.php
@@ -65,6 +65,11 @@ class WsseMiddleware extends Middleware
     /**
      * @var bool
      */
+    private $mustUnderstand = true;
+
+    /**
+     * @var bool
+     */
     private $serverCertificateHasSubjectKeyIdentifier = true;
 
     public function __construct(array $properties)
@@ -127,7 +132,7 @@ class WsseMiddleware extends Middleware
     public function beforeRequest(callable $handler, RequestInterface $request): Promise
     {
         $xml = SoapXml::fromStream($request->getBody());
-        $wsse = new WSSESoap($xml->getXmlDocument());
+        $wsse = new WSSESoap($xml->getXmlDocument(), $this->mustUnderstand);
 
         // Prepare the WSSE soap class:
         $wsse->signAllHeaders = $this->signAllHeaders;

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -40,6 +40,21 @@ class SoapClientTest extends TestCase
         self::assertTrue($response->ok());
     }
 
+    public function testWsseWithWsaCall()
+    {
+        Soap::fake();
+        $client = Soap::baseWsdl('https://laravel-soap.wsdl')->withWsse([
+            'userTokenName' => 'Test',
+            'userTokenPassword' => 'passwordTest',
+            'mustUnderstand' => false
+        ])->withWsa();
+        $response = $client->Get_User();
+        $lastRequestInfo = $client->getEngine()->collectLastRequestInfo();
+        self::assertStringNotContainsString( 'mustUnderstand', $lastRequestInfo->getLastRequest());
+//        dd($client->debugLastSoapRequest());
+        self::assertTrue($response->ok());
+    }
+
     public function testArrayAccessResponse()
     {
         Soap::fakeSequence()->push('test');

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -46,11 +46,11 @@ class SoapClientTest extends TestCase
         $client = Soap::baseWsdl('https://laravel-soap.wsdl')->withWsse([
             'userTokenName' => 'Test',
             'userTokenPassword' => 'passwordTest',
-            'mustUnderstand' => false
+            'mustUnderstand' => false,
         ])->withWsa();
         $response = $client->Get_User();
         $lastRequestInfo = $client->getEngine()->collectLastRequestInfo();
-        self::assertStringNotContainsString( 'mustUnderstand', $lastRequestInfo->getLastRequest());
+        self::assertStringNotContainsString('mustUnderstand', $lastRequestInfo->getLastRequest());
 //        dd($client->debugLastSoapRequest());
         self::assertTrue($response->ok());
     }


### PR DESCRIPTION
Added mustUnderstand option for Wsse Header
````php
        $client = Soap::baseWsdl('https://laravel-soap.wsdl')->withWsse([
            'userTokenName' => 'Test',
            'userTokenPassword' => 'passwordTest',
            'mustUnderstand' => false
        ])->withWsa();
````
