### PR TITLE
fix(feature/laravel soap-141): typo in factory & added unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 .env.test
 .phpunit.result.cache
+/phpunit.xml.bak

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
+         backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false"
+         stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Laravel Soap Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="API_PREFIX" value="api"/>

--- a/src/Facades/Soap.php
+++ b/src/Facades/Soap.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * Class Soap.
  *
+ * @method static \CodeDredd\Soap\Handler\HttPlugHandle getHandler()
  * @method static \CodeDredd\Soap\SoapClient baseWsdl(string $wsdl)
  * @method static \CodeDredd\Soap\SoapClient stub(callable $callback)
  * @method static \CodeDredd\Soap\SoapClient buildClient(string $setup = '')

--- a/src/Facades/Soap.php
+++ b/src/Facades/Soap.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \CodeDredd\Soap\SoapClient byConfig(string $setup = '')
  * @method static \CodeDredd\Soap\SoapClient withOptions(array $options)
  * @method static \CodeDredd\Soap\SoapClient withHeaders(array $options)
- * @method static \CodeDredd\Soap\SoapClient handlerOptions(array $options)
+ * @method static \CodeDredd\Soap\SoapClient withHandlerOptions(array $options)
  * @method static \CodeDredd\Soap\SoapClient withWsse(array $config)
  * @method static \CodeDredd\Soap\SoapClient withWsa()
  * @method static \CodeDredd\Soap\SoapClient withRemoveEmptyNodes()

--- a/src/Handler/HttPlugHandle.php
+++ b/src/Handler/HttPlugHandle.php
@@ -3,6 +3,7 @@
 namespace CodeDredd\Soap\Handler;
 
 use CodeDredd\Soap\HttpBinding\Converter\Psr7Converter;
+use GuzzleHttp\Client;
 use Http\Client\Common\PluginClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
@@ -15,12 +16,11 @@ use Phpro\SoapClient\Soap\Handler\LastRequestInfoCollectorInterface;
 use Phpro\SoapClient\Soap\HttpBinding\LastRequestInfo;
 use Phpro\SoapClient\Soap\HttpBinding\SoapRequest;
 use Phpro\SoapClient\Soap\HttpBinding\SoapResponse;
-use Psr\Http\Client\ClientInterface;
 
 class HttPlugHandle implements HandlerInterface, MiddlewareSupportingInterface
 {
     /**
-     * @var ClientInterface
+     * @var Client
      */
     private $client;
 
@@ -45,7 +45,7 @@ class HttPlugHandle implements HandlerInterface, MiddlewareSupportingInterface
     private $requestHeaders = [];
 
     public function __construct(
-        ClientInterface $client,
+        Client $client,
         Psr7Converter $converter,
         CollectLastRequestInfoMiddleware $lastRequestInfoCollector,
         $requestHeaders = []
@@ -61,7 +61,7 @@ class HttPlugHandle implements HandlerInterface, MiddlewareSupportingInterface
         return self::createForClient(HttpClientDiscovery::find());
     }
 
-    public static function createForClient(ClientInterface $client, $requestHeaders = []): HttPlugHandle
+    public static function createForClient(Client $client, $requestHeaders = []): HttPlugHandle
     {
         return new self(
             $client,
@@ -93,6 +93,11 @@ class HttPlugHandle implements HandlerInterface, MiddlewareSupportingInterface
         $psr7Response = $client->sendRequest($psr7Request);
 
         return $this->converter->convertSoapResponse($psr7Response);
+    }
+
+    public function getClient(): Client
+    {
+        return $this->client;
     }
 
     public function collectLastRequestInfo(): LastRequestInfo

--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -53,7 +53,7 @@ class SoapClient
     protected $extSoapOptions;
 
     /**
-     * @var
+     * @var HttPlugHandle
      */
     protected $handler;
 
@@ -162,6 +162,11 @@ class SoapClient
         return $this->withHandlerOptions(array_merge_recursive($this->options, [
             'headers' => $headers,
         ]));
+    }
+
+    public function getHandler(): HttPlugHandle
+    {
+        return $this->handler;
     }
 
     /**


### PR DESCRIPTION
- changed the punit.xml to the new format
- added new function `getHandler` to access the current handler with its guzzle client instance
- added  unit tests