### PR TITLE
Arguments are parsed from body instead of xmlContent

### DIFF
--- a/src/Client/Request.php
+++ b/src/Client/Request.php
@@ -155,7 +155,7 @@ class Request
      */
     public function arguments(): array
     {
-        $doc = Document::fromXmlString($this->xmlContent());
+        $doc = Document::fromXmlString($this->body());
         $method = $doc->locate(new SoapBodyLocator())?->firstElementChild;
 
         return Arr::wrap(Arr::get(element_decode($method, traverse(new RemoveNamespaces())), 'node', []));

--- a/tests/Unit/SoapClientTest.php
+++ b/tests/Unit/SoapClientTest.php
@@ -254,6 +254,19 @@ class SoapClientTest extends TestCase
         Soap::assertActionCalled('GetWeatherInformation');
     }
 
+    public function testArgumentsCanBeCalledTwice(): void
+    {
+        Soap::fake();
+        Event::fake();
+        Soap::assertNothingSent();
+        $response = Soap::baseWsdl(dirname(__DIR__, 1).'/Fixtures/Wsdl/weather.wsdl')
+            ->call('GetWeatherInformation');
+        self::assertTrue($response->ok());
+        Soap::assertSent(function (Request $request) {
+            return $request->arguments() === $request->arguments();
+        });
+    }
+
     public function soapHeaderProvider(): array
     {
         $header = [


### PR DESCRIPTION
Issue:

PSR7 StreamInterface docblock of getContents() says 
```php
/**
 * Returns the remaining contents in a string
 *
 * @return string
 * @throws \RuntimeException if unable to read or an error occurs while
 *     reading.
 */
public function getContents();
```

but casting StreamInterface to string returns the whole stream
```php
/**
 * Reads all data from the stream into a string, from the beginning to end.
 *
 *  [...]
 */
public function __toString();
```

As `Request::arguments` calls `StreamInterface::getContents`, `Document::fromXmlString` gets the remaining content of the stream and not the whole thing, which can cause issues like :

```
ValueError: DOMDocument::loadXML(): Argument #1 ($source) must not be empty

/path/to/project/vendor/veewee/xml/src/Xml/Dom/Loader/xml_string_loader.php:17
/path/to/project/vendor/veewee/xml/src/Xml/Dom/Loader/load.php:20
/path/to/project/vendor/azjezz/psl/src/Psl/Result/wrap.php:22
/path/to/project/vendor/veewee/xml/src/Xml/ErrorHandling/detect_issues.php:32
/path/to/project/vendor/veewee/xml/src/Xml/ErrorHandling/disallow_issues.php:20
/path/to/project/vendor/veewee/xml/src/Xml/Dom/Loader/load.php:23
/path/to/project/vendor/veewee/xml/src/Xml/Dom/Loader/xml_string_loader.php:17
/path/to/project/vendor/veewee/xml/src/Xml/Dom/Configurator/loader.php:17
/path/to/project/vendor/azjezz/psl/src/Psl/Fun/pipe.php:44
/path/to/project/vendor/azjezz/psl/src/Psl/Iter/reduce.php:36
/path/to/project/vendor/azjezz/psl/src/Psl/Fun/pipe.php:37
/path/to/project/vendor/veewee/xml/src/Xml/Dom/Document.php:41
/path/to/project/vendor/veewee/xml/src/Xml/Dom/Document.php:69
/path/to/project/vendor/codedredd/laravel-soap/src/Client/Request.php:158
```

when trying to get the arguments twice

## What I did

`Request::arguments` now calls `body()` instead of `xmlContent()` in order to get the whole body, which makes sense because of PSR7 specifications.

## How to test

One way to test it is to try reading twice the request content. Before this fix, an error is thrown at second reading. 

- Does this need an update to the documentation?

no
